### PR TITLE
Fix protected route signup redirect

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -21,7 +21,7 @@ export default function ProtectedRoute({ children }: { children: React.ReactNode
   }
 
   // Redirect to dashboard if user tries to access login page while already authenticated
-  if (user && (location.pathname === '/auth' || location.pathname === '/cadastro')) {
+  if (user && (location.pathname === '/auth' || location.pathname === '/signup')) {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/src/components/layout/ProtectedRoute.tsx
+++ b/src/components/layout/ProtectedRoute.tsx
@@ -25,7 +25,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
   }
 
   // Redirect to dashboard if user tries to access login page while already authenticated
-  if (user && (location.pathname === '/auth' || location.pathname === '/cadastro')) {
+  if (user && (location.pathname === '/auth' || location.pathname === '/signup')) {
     return <Navigate to="/dashboard" replace />;
   }
 


### PR DESCRIPTION
## Summary
- fix the path check for signed-in users in ProtectedRoute

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848c71288a08332b1812d1c82a7cd2f