### PR TITLE
Fix AuthContext cleanup interval

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -19,6 +19,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
 
+  // Interval handler used to refresh the token periodically
+  let tokenRefreshInterval: ReturnType<typeof setInterval> | undefined;
+
   // Função para atualizar a sessão
   const refreshSession = async () => {
     try {
@@ -64,16 +67,14 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setSession(session);
       setUser(session?.user ?? null);
       setLoading(false);
-      
+
       // Configura um intervalo para renovar o token periodicamente (a cada 55 minutos)
-      const tokenRefreshInterval = setInterval(refreshSession, 55 * 60 * 1000);
-      
-      // Limpa o intervalo quando o componente é desmontado
-      return () => clearInterval(tokenRefreshInterval);
+      tokenRefreshInterval = setInterval(refreshSession, 55 * 60 * 1000);
     });
 
     return () => {
       subscription.unsubscribe();
+      if (tokenRefreshInterval) clearInterval(tokenRefreshInterval);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- keep auth token refresh interval in scope
- clear the interval when the effect cleans up

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848d00cd03883328ce62b48cb3b2d45