### PR TITLE
Use env vars for Stripe price IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment variables
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
+# Stripe price IDs for each plan
+PRICE_ID_STARTER_MONTHLY=
+PRICE_ID_STARTER_YEARLY=
+PRICE_ID_PRO_MONTHLY=
+PRICE_ID_PRO_YEARLY=
+PRICE_ID_PREMIUM_MONTHLY=
+PRICE_ID_PREMIUM_YEARLY=
+
+# Application URL used by Supabase functions
+APP_URL=

--- a/README.md
+++ b/README.md
@@ -66,8 +66,15 @@ The application expects the following variables at build time:
 
 - `VITE_SUPABASE_URL` – your Supabase project URL.
 - `VITE_SUPABASE_ANON_KEY` – the public anon key for your project.
+- `PRICE_ID_STARTER_MONTHLY` – Stripe price ID for the monthly Starter plan.
+- `PRICE_ID_STARTER_YEARLY` – Stripe price ID for the yearly Starter plan.
+- `PRICE_ID_PRO_MONTHLY` – Stripe price ID for the monthly Pro plan.
+- `PRICE_ID_PRO_YEARLY` – Stripe price ID for the yearly Pro plan.
+- `PRICE_ID_PREMIUM_MONTHLY` – Stripe price ID for the monthly Premium plan.
+- `PRICE_ID_PREMIUM_YEARLY` – Stripe price ID for the yearly Premium plan.
+- `APP_URL` – base URL used by Supabase functions when no `origin` header is provided.
 
-Create a `.env` file in the project root and define these values when running locally.
+Create a `.env` file in the project root and define these values when running locally or configure them in the Supabase dashboard for your functions.
 
 ## How can I deploy this project?
 

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -28,22 +28,31 @@ const corsHeaders = {
 
 // Plan configuration with Stripe Price IDs
 const getPlanConfig = (planId: string, isYearly: boolean): PlanConfig => {
-  switch(planId) {
-    case 'starter':
+  switch (planId) {
+    case 'starter': {
+      const monthly = Deno.env.get('PRICE_ID_STARTER_MONTHLY');
+      const yearly = Deno.env.get('PRICE_ID_STARTER_YEARLY');
       return {
-        name: "Plano Starter",
-        priceId: isYearly ? "price_1RNNv2RkF2Xmse9MjGNrg4wk" : "price_1RNNtORkF2Xmse9MudMyCXMt"
+        name: 'Plano Starter',
+        priceId: isYearly ? (yearly ?? '') : (monthly ?? ''),
       };
-    case 'pro':
+    }
+    case 'pro': {
+      const monthly = Deno.env.get('PRICE_ID_PRO_MONTHLY');
+      const yearly = Deno.env.get('PRICE_ID_PRO_YEARLY');
       return {
-        name: "Plano Pro", 
-        priceId: isYearly ? "price_1RNNx3RkF2Xmse9Mz9Hu9f22" : "price_1RNNw9RkF2Xmse9MVAoYhg3u"
+        name: 'Plano Pro',
+        priceId: isYearly ? (yearly ?? '') : (monthly ?? ''),
       };
-    case 'premium':
+    }
+    case 'premium': {
+      const monthly = Deno.env.get('PRICE_ID_PREMIUM_MONTHLY');
+      const yearly = Deno.env.get('PRICE_ID_PREMIUM_YEARLY');
       return {
-        name: "Plano Premium",
-        priceId: isYearly ? "price_1RNNzFRkF2Xmse9Mr6D34kM9" : "price_1RNNxgRkF2Xmse9MGKFxwHZc"
+        name: 'Plano Premium',
+        priceId: isYearly ? (yearly ?? '') : (monthly ?? ''),
       };
+    }
     default:
       throw new Error(`Plano '${planId}' não é válido`);
   }
@@ -196,7 +205,7 @@ serve(async (req) => {
     const planConfig = getPlanConfig(planId, isYearly);
     const customerId = await getOrCreateCustomer(stripe, supabase, user);
     
-    const origin = req.headers.get("origin") || "https://09df458b-dedc-46e2-af46-e15d28209b01.lovableproject.com";
+    const origin = req.headers.get("origin") || Deno.env.get('APP_URL') || "";
     const session = await createCheckoutSession(
       stripe,
       customerId,


### PR DESCRIPTION
## Summary
- load checkout price IDs from environment variables
- respect `APP_URL` when origin header is missing
- document the new variables in README
- provide an `.env.example` file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848d4b57b6483329c80ded9a069ce2c