### PR TITLE
Refactor Stripe utilities

### DIFF
--- a/supabase/functions/_shared/stripeUtils.ts
+++ b/supabase/functions/_shared/stripeUtils.ts
@@ -1,0 +1,63 @@
+export interface AuthenticatedUser {
+  user: any;
+  supabase: any;
+}
+
+export const authenticateUser = async (authHeader: string | null): Promise<AuthenticatedUser> => {
+  if (!authHeader) {
+    throw new Error("Autorização necessária");
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("Variáveis do Supabase não configuradas");
+  }
+
+  const { createClient } = await import("https://esm.sh/@supabase/supabase-js@2.38.0");
+
+  const supabase = createClient(supabaseUrl, supabaseAnonKey);
+  const token = authHeader.replace("Bearer ", "");
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+
+  if (authError || !user) {
+    throw new Error("Usuário não autenticado");
+  }
+
+  console.log("✅ Usuário autenticado:", user.email);
+  return { user, supabase };
+};
+
+export const getOrCreateCustomer = async (
+  stripe: any,
+  supabase: any,
+  user: any
+): Promise<string> => {
+  const { data: subscriber } = await supabase
+    .from("subscribers")
+    .select("stripe_customer_id")
+    .eq("user_id", user.id)
+    .single();
+
+  let customerId = subscriber?.stripe_customer_id;
+
+  if (!customerId) {
+    console.log("🆕 Criando novo cliente Stripe");
+    const customer = await stripe.customers.create({
+      email: user.email,
+      metadata: {
+        user_id: user.id,
+      },
+    });
+    customerId = customer.id;
+
+    await supabase.from("subscribers").upsert({
+      user_id: user.id,
+      email: user.email,
+      stripe_customer_id: customerId,
+    });
+  }
+
+  return customerId;
+};

--- a/supabase/functions/verify-subscription/index.ts
+++ b/supabase/functions/verify-subscription/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@13.2.0?target=deno";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.0";
+import { authenticateUser } from "../_shared/stripeUtils.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -16,21 +16,7 @@ serve(async (req) => {
 
   try {
     const authHeader = req.headers.get("Authorization");
-    if (!authHeader) {
-      throw new Error("Autorização necessária");
-    }
-
-    const supabaseUrl = Deno.env.get("SUPABASE_URL") || "";
-    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY") || "";
-    const supabase = createClient(supabaseUrl, supabaseAnonKey);
-
-    // Verificar autenticação
-    const token = authHeader.replace("Bearer ", "");
-    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-
-    if (authError || !user) {
-      throw new Error("Usuário não autenticado");
-    }
+    const { user, supabase } = await authenticateUser(authHeader);
 
     // Inicializar Stripe
     const stripe = new Stripe(Deno.env.get("STRIPE_SECRET_KEY") || "", {


### PR DESCRIPTION
## Summary
- create shared stripe utils for Supabase Edge functions
- refactor `create-checkout-session` to use new helpers
- refactor `verify-subscription` to reuse helper

## Testing
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d59474cc83329b49cfc04be5d72b