### PR TITLE
Fix theme inconsistency on standalone pages

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 
 const About = () => {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-plush-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-plush-50 to-purple-50 dark:from-plush-900 dark:to-purple-950">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="text-center mb-16">
           <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-6">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -12,11 +12,14 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center bg-background">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
+        <p className="text-xl text-muted-foreground mb-4">Oops! Page not found</p>
+        <Link
+          to="/"
+          className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline"
+        >
           Return to Home
         </Link>
       </div>

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -52,8 +52,8 @@ const PaymentSuccess = () => {
   };
   
   return (
-    <div className="min-h-screen pt-20 pb-10 flex items-center justify-center">
-      <div className="max-w-md w-full bg-white rounded-xl shadow-lg p-8 mx-4">
+    <div className="min-h-screen bg-background pt-20 pb-10 flex items-center justify-center">
+      <div className="max-w-md w-full bg-white dark:bg-card rounded-xl shadow-lg p-8 mx-4">
         <div className="flex flex-col items-center text-center">
           <div className="w-16 h-16 bg-plush-50 rounded-full flex items-center justify-center mb-6">
             <CheckCircle className="text-plush-600 w-9 h-9" />
@@ -62,22 +62,22 @@ const PaymentSuccess = () => {
           <h1 className="text-2xl font-bold mb-2 font-serif">Pagamento Confirmado!</h1>
           
           {isLoading ? (
-            <p className="text-gray-500 mb-6">Verificando seu pagamento...</p>
+            <p className="text-muted-foreground mb-6">Verificando seu pagamento...</p>
           ) : isSubscribed ? (
             <>
-              <p className="text-gray-500 mb-1">
+              <p className="text-muted-foreground mb-1">
                 Parabéns! Sua assinatura do plano <span className="font-medium text-plush-700">{getPlanName()}</span> foi ativada com sucesso.
               </p>
-              <p className="text-gray-500 mb-6">
+              <p className="text-muted-foreground mb-6">
                 Você já pode começar a aproveitar todos os benefícios do seu novo plano agora mesmo.
               </p>
             </>
           ) : (
             <>
-              <p className="text-gray-500 mb-1">
+              <p className="text-muted-foreground mb-1">
                 Seu pagamento foi recebido, mas pode levar alguns minutos para que sua assinatura seja ativada.
               </p>
-              <p className="text-gray-500 mb-6">
+              <p className="text-muted-foreground mb-6">
                 Caso não seja ativada automaticamente, entre em contato com nosso suporte.
               </p>
             </>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -82,7 +82,7 @@ const Signup = () => {
 
   return (
     <div className="min-h-screen bg-background p-4 md:p-8">
-      <div className="max-w-md mx-auto bg-white rounded-xl shadow-sm border border-plush-100 p-6 md:p-8">
+      <div className="max-w-md mx-auto bg-white dark:bg-card rounded-xl shadow-sm border border-plush-100 p-6 md:p-8">
         <div className="flex items-center gap-2 mb-6">
           <UserPlus className="w-6 h-6 text-plush-600" />
           <h1 className="text-2xl font-bold">Cadastre-se no Plushify</h1>


### PR DESCRIPTION
## Summary
- adjust About page gradient for dark mode
- make signup/payment success containers dark-theme aware
- adapt 404 page colors to theme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848d66f1f848332bd0907112a67d808