### PR TITLE
Add caching and rate limiting to backend functions

### DIFF
--- a/supabase/functions/create-checkout/index.ts
+++ b/supabase/functions/create-checkout/index.ts
@@ -13,6 +13,10 @@ const logStep = (step: string, details?: any) => {
   console.log(`[CREATE-CHECKOUT] ${step}${detailsStr}`);
 };
 
+// Simple per-user rate limiting
+const RATE_LIMIT_WINDOW_MS = 30 * 1000; // 30 seconds
+const userRequestTimestamps = new Map<string, number>();
+
 // SEGURANÇA: Price IDs oficiais - Vamos criar preços de teste que funcionem
 const OFFICIAL_PRICE_IDS = {
   professional: {
@@ -116,6 +120,17 @@ serve(async (req) => {
     const token = authHeader.replace("Bearer ", "");
     const user = await validateUserAuth(token, supabaseClient);
     logStep("SECURITY: User authenticated successfully", { userId: user.id, email: user.email });
+
+    // Rate limiting: prevent repeated checkouts
+    const lastRequest = userRequestTimestamps.get(user.id) || 0;
+    if (Date.now() - lastRequest < RATE_LIMIT_WINDOW_MS) {
+      logStep("Rate limit triggered", { userId: user.id });
+      return new Response(JSON.stringify({ error: "Too many requests" }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 429,
+      });
+    }
+    userRequestTimestamps.set(user.id, Date.now());
 
     // SEGURANÇA: Parsing e validação de entrada
     let requestBody;


### PR DESCRIPTION
## Summary
- implement in-memory caching for user subscription checks
- add simple rate limiting to checkout creation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685818085d28833291be36571f57c7c0